### PR TITLE
Removes unnecessary "fs" require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+package-lock.json
 
 # Typescript v1 declaration files
 typings/

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var getRandomValues = require('get-random-values');
-var fs = require("fs");
 
 var hardLimit = 100,
     ellipsis = "\u2026",


### PR DESCRIPTION
The module `fs` is not being used at all, no point in requiring it on `index.js`. Besides, I was having a problem with this require on my project:

```
Module not found. Error: Can't resolve 'fs' in 'node_modules/node-jsencrypt'
```

This PR fixes the issue.