### PR TITLE
fix: KJUR is not defined with rollup

### DIFF
--- a/index.js
+++ b/index.js
@@ -2779,7 +2779,9 @@ ASN1.test = function () {
      * @name KJUR
      * @namespace kjur's class library name space
      */
-    if (typeof KJUR == "undefined" || !KJUR) KJUR = {};
+    if (typeof KJUR == "undefined" || !KJUR) {
+        var KJUR = {};
+    }
 
     /**
      * kjur's ASN.1 class library name space


### PR DESCRIPTION
Hello, thank you for porting the library!

I use nodejs to write a library, it with rollup to support browser, but I am not sure if it is a configuration problem, an error occurred in the browser: `ReferenceError, KJUR is not defined`.

So I am based on [travist/jsencrypt](https://github.com/travist/jsencrypt/blob/master/bin/jsencrypt.js#L3286) has been modified.